### PR TITLE
Add transform-module-specifiers plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Curated list for the SWC projects.
 - [`swc-plugin-import-meta-env`](https://github.com/Codex-/swc-plugin-import-meta-env) - A plugin to transform `import.meta.env` to `process.env`.
 - [`@swc-jotai/react-refresh`](https://github.com/pmndrs/swc-jotai) - A plugin for supporting React Refresh with Jotai.
 - [`@formatjs/swc-plugin`](https://github.com/formatjs/formatjs/tree/main/packages/swc-plugin) - A plugin for FormatJS.
+- [`swc-plugin-transform-module-specifiers`](https://github.com/1zumii/swc-plugin-transform-module-specifiers) - A plugin for transforming file extensions in import, export path.
 
 ## Packages
 


### PR DESCRIPTION
Add [`transform-module-specifiers`](https://github.com/1zumii/swc-plugin-transform-module-specifiers) to third party plugins,
A plugin for transforming file extensions in import, export path.